### PR TITLE
Feat: display intercept failure message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14289,6 +14289,12 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -17067,9 +17073,9 @@
       }
     },
     "js-base64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
-      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
     "js-tokens": {
@@ -17347,6 +17353,15 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
     },
     "left-pad": {
       "version": "1.3.0",
@@ -18842,9 +18857,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-gyp": {
@@ -19009,9 +19024,9 @@
       }
     },
     "node-sass": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
-      "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+      "integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -19028,7 +19043,7 @@
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
-        "sass-graph": "2.2.5",
+        "sass-graph": "^2.2.4",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
       },
@@ -19351,6 +19366,18 @@
             "trim-newlines": "^3.0.0",
             "type-fest": "^0.13.1",
             "yargs-parser": "^18.1.3"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "18.1.3",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+              "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         },
         "npm-run-path": {
@@ -20155,6 +20182,15 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -25799,137 +25835,220 @@
       }
     },
     "sass-graph": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
-      "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.6.tgz",
+      "integrity": "sha512-MKuEYXFSGuRSi8FZ3A7imN1CeVn9Gpw0/SFJKdL1ejXJneI9a5rwlEZrKejhEFAA3O6yr3eIyl/WuvASvlT36g==",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "lodash": "^4.0.0",
         "scss-tokenizer": "^0.2.3",
-        "yargs": "^13.3.2"
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
         },
         "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "number-is-nan": "^1.0.0"
           }
         },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^2.0.0"
           }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
         },
         "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           }
         },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
         "yargs": {
-          "version": "13.3.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+          "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
           "dev": true,
           "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
+            "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "5.0.0-security.0"
           }
         },
         "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "version": "5.0.0-security.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+          "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "camelcase": "^3.0.0",
+            "object.assign": "^4.1.0"
           }
         }
       }
@@ -26051,6 +26170,14 @@
       "dev": true,
       "requires": {
         "node-forge": "0.9.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+          "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+          "dev": true
+        }
       }
     },
     "semver": {
@@ -29526,6 +29653,12 @@
         "yargs-parser": "^18.1.1"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -29559,13 +29692,23 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
     "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.4",
     "gh-pages": "^3.0.0",
+    "http-proxy": "^1.18.1",
     "identity-obj-proxy": "^3.0.0",
     "immutable": "3.8.2",
     "jest": "^26.0.1",
@@ -86,7 +87,8 @@
     "jest-resolve": "^26.0.1",
     "jest-watch-typeahead": "^0.6.0",
     "kind-of": "^6.0.3",
-    "node-sass": "^4.14.1",
+    "node-forge": "^0.10.0",
+    "node-sass": "^4.13.1",
     "np": "^6.2.4",
     "npm-run-all": "^4.1.5",
     "postcss": "^7.0.32",
@@ -103,6 +105,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.3",
     "rollup-plugin-postcss": "^3.1.2",
     "rollup-plugin-smart-asset": "^2.0.7",
-    "sass": "^1.26.8"
+    "sass": "^1.26.8",
+    "yargs-parser": "^13.1.2"
   }
 }

--- a/src/Components/NetworkTable/NetworkCellValue.jsx
+++ b/src/Components/NetworkTable/NetworkCellValue.jsx
@@ -13,24 +13,37 @@ const NetworkCellValue = ({ datakey, unit, payload }) => {
   const [isOpen, updateOpen] = useState(false);
   const displayPopover = () => updateOpen(true);
   const hidePopover = () => updateOpen(false);
-  const formatedValue = formatValue(datakey, payload[datakey], unit);
-  const title = datakey === VIEWER_FIELDS.file.key ? payload.url : formatedValue;
+  const formattedValue = formatValue(datakey, payload[datakey], unit, payload);
+  const shouldDisplayTooltip = (
+    datakey === VIEWER_FIELDS.file.key ||
+    payload.error
+  );
 
-  if (datakey !== VIEWER_FIELDS.file.key) {
+  const getTitle = () => {
+    if (datakey === VIEWER_FIELDS.file.key) {
+      return payload.url;
+    }
+    if (payload.error) {
+      return payload.error;
+    }
+
+    return formattedValue;
+  };
+
+  if (!shouldDisplayTooltip) {
     return (
       <td className={context('value-cell', datakey)}>
         <span className={Styles['value-text']}>
-          {formatedValue}
+          {formattedValue}
         </span>
       </td>
     );
   }
 
-  // Render popover only for file column value
   return (
     <td className={context('value-cell', datakey)}>
       <Popover
-        body={<span className={Styles['url-tooltip']}>{title}</span>}
+        body={<span className={Styles['url-tooltip']}>{getTitle()}</span>}
         isOpen={isOpen}
         preferPlace="below"
       >
@@ -39,7 +52,7 @@ const NetworkCellValue = ({ datakey, unit, payload }) => {
           onMouseOut={hidePopover}
           onMouseOver={displayPopover}
         >
-          {formatedValue}
+          {formattedValue}
         </span>
       </Popover>
     </td>

--- a/src/Components/NetworkTable/NetworkTableRow.jsx
+++ b/src/Components/NetworkTable/NetworkTableRow.jsx
@@ -24,7 +24,7 @@ const NetworkTableRow = ({
   const rowProps = {
     className: context(
       'network-table-row',
-      getStatusClass(payload.status), {
+      getStatusClass(payload), {
         highlight: scrollHighlight,
       }),
     id: ROW_ID_PREFIX + payload.index,

--- a/src/Components/ReqDetail/headers/General.jsx
+++ b/src/Components/ReqDetail/headers/General.jsx
@@ -15,7 +15,7 @@ const General = ({ data }) => (
           {`${name}:`}
         </span>
         <span className={Styles['info-value']}>
-          {data[key]}
+          {key === 'status' && data.error ? data.error : data[key]}
         </span>
       </p>
     ))}

--- a/tests/__fixtures__/network_intercept_error.json
+++ b/tests/__fixtures__/network_intercept_error.json
@@ -1,0 +1,1035 @@
+{
+  "log": {
+      "version": "1.2",
+      "creator": {
+          "name": "ExtendedDebuggingService",
+          "version": "0.28.35"
+      },
+      "pages": [
+          {
+              "startedDateTime": "2020-09-16T12:55:37.093Z",
+              "id": "E32BAE846A2DC6C0D40715BDC403ADC6",
+              "title": "https://www.json.org/",
+              "pageTimings": {
+                  "onContentLoad": 444.69399999999837,
+                  "onLoad": 384.98599999999783
+              },
+              "_wallTime": 1600260937.093776,
+              "_monotonicTimestamp": 56.417865
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.547Z",
+              "id": "0908A2D2117805883D74919A844510C3",
+              "title": "https://www.json.org/json-en.html",
+              "pageTimings": {
+                  "onContentLoad": 127.00099999999992,
+                  "onLoad": 441.11999999999796
+              },
+              "_wallTime": 1600260937.547163,
+              "_monotonicTimestamp": 56.871673
+          }
+      ],
+      "entries": [
+          {
+              "startedDateTime": "2020-09-16T12:55:37.093Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": ":method",
+                          "value": "GET"
+                      },
+                      {
+                          "name": ":authority",
+                          "value": "www.json.org"
+                      },
+                      {
+                          "name": ":scheme",
+                          "value": "https"
+                      },
+                      {
+                          "name": ":path",
+                          "value": "/"
+                      },
+                      {
+                          "name": "pragma",
+                          "value": "no-cache"
+                      },
+                      {
+                          "name": "cache-control",
+                          "value": "no-cache"
+                      },
+                      {
+                          "name": "upgrade-insecure-requests",
+                          "value": "1"
+                      },
+                      {
+                          "name": "user-agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "sec-fetch-dest",
+                          "value": "document"
+                      },
+                      {
+                          "name": "accept",
+                          "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+                      },
+                      {
+                          "name": "sec-fetch-site",
+                          "value": "none"
+                      },
+                      {
+                          "name": "sec-fetch-mode",
+                          "value": "navigate"
+                      },
+                      {
+                          "name": "sec-fetch-user",
+                          "value": "?1"
+                      },
+                      {
+                          "name": "accept-encoding",
+                          "value": "gzip, deflate, br"
+                      },
+                      {
+                          "name": "accept-language",
+                          "value": "en-US,en;q=0.9"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 200,
+                  "statusText": "",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "status",
+                          "value": "200"
+                      },
+                      {
+                          "name": "content-type",
+                          "value": "text/html"
+                      },
+                      {
+                          "name": "date",
+                          "value": "Wed, 16 Sep 2020 12:55:36 GMT"
+                      },
+                      {
+                          "name": "server",
+                          "value": "Apache"
+                      },
+                      {
+                          "name": "last-modified",
+                          "value": "Sat, 30 Nov 2019 04:00:27 GMT"
+                      },
+                      {
+                          "name": "etag",
+                          "value": "W/\"106-5988862f8ccc0\""
+                      },
+                      {
+                          "name": "content-encoding",
+                          "value": "gzip"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 0,
+                      "mimeType": "text/html"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 262
+              },
+              "time": 306.29300000000603,
+              "cache": {},
+              "timings": {
+                  "blocked": 87.0090000000018,
+                  "connect": 139.756,
+                  "dns": 0.014999999999986358,
+                  "receive": 7.4600000000017985,
+                  "send": 1.6730000000000018,
+                  "ssl": 85.43700000000001,
+                  "wait": 70.38000000000244,
+                  "_blocked_queueing": 7.4600000000017985
+              },
+              "pageref": "E32BAE846A2DC6C0D40715BDC403ADC6"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.547Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/json-en.html",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": ":method",
+                          "value": "GET"
+                      },
+                      {
+                          "name": ":authority",
+                          "value": "www.json.org"
+                      },
+                      {
+                          "name": ":scheme",
+                          "value": "https"
+                      },
+                      {
+                          "name": ":path",
+                          "value": "/json-en.html"
+                      },
+                      {
+                          "name": "pragma",
+                          "value": "no-cache"
+                      },
+                      {
+                          "name": "cache-control",
+                          "value": "no-cache"
+                      },
+                      {
+                          "name": "upgrade-insecure-requests",
+                          "value": "1"
+                      },
+                      {
+                          "name": "user-agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "sec-fetch-dest",
+                          "value": "document"
+                      },
+                      {
+                          "name": "accept",
+                          "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+                      },
+                      {
+                          "name": "sec-fetch-site",
+                          "value": "same-origin"
+                      },
+                      {
+                          "name": "sec-fetch-mode",
+                          "value": "navigate"
+                      },
+                      {
+                          "name": "referer",
+                          "value": "https://www.json.org/"
+                      },
+                      {
+                          "name": "accept-encoding",
+                          "value": "gzip, deflate, br"
+                      },
+                      {
+                          "name": "accept-language",
+                          "value": "en-US,en;q=0.9"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 200,
+                  "statusText": "",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "status",
+                          "value": "200"
+                      },
+                      {
+                          "name": "content-type",
+                          "value": "text/html"
+                      },
+                      {
+                          "name": "date",
+                          "value": "Wed, 16 Sep 2020 12:55:37 GMT"
+                      },
+                      {
+                          "name": "server",
+                          "value": "Apache"
+                      },
+                      {
+                          "name": "last-modified",
+                          "value": "Tue, 28 Jan 2020 14:36:17 GMT"
+                      },
+                      {
+                          "name": "etag",
+                          "value": "W/\"685e-59d342586ba40\""
+                      },
+                      {
+                          "name": "content-encoding",
+                          "value": "gzip"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 0,
+                      "mimeType": "text/html"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 26718
+              },
+              "time": 95.31199999999984,
+              "cache": {},
+              "timings": {
+                  "blocked": 9.927000000002295,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 9.427000000002295,
+                  "send": 0.31200000000000006,
+                  "ssl": -1,
+                  "wait": 75.64599999999525,
+                  "_blocked_queueing": 9.427000000002295
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.545Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/favicon.ico",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 200,
+                  "statusText": "",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "date",
+                          "value": "Wed, 16 Sep 2020 12:55:37 GMT"
+                      },
+                      {
+                          "name": "last-modified",
+                          "value": "Fri, 27 Jan 2012 21:02:14 GMT"
+                      },
+                      {
+                          "name": "server",
+                          "value": "Apache"
+                      },
+                      {
+                          "name": "etag",
+                          "value": "\"3dd-4b788cfa56180\""
+                      },
+                      {
+                          "name": "content-type",
+                          "value": "image/vnd.microsoft.icon"
+                      },
+                      {
+                          "name": "status",
+                          "value": "200"
+                      },
+                      {
+                          "name": "accept-ranges",
+                          "value": "bytes"
+                      },
+                      {
+                          "name": "content-length",
+                          "value": "989"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 989,
+                      "mimeType": "image/vnd.microsoft.icon"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 989
+              },
+              "time": 88.92100000000625,
+              "cache": {},
+              "timings": {
+                  "blocked": 10.908000000002597,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 10.395000000002597,
+                  "send": 0.6789999999999999,
+                  "ssl": -1,
+                  "wait": 66.93900000000106,
+                  "_blocked_queueing": 10.395000000002597
+              },
+              "pageref": "E32BAE846A2DC6C0D40715BDC403ADC6"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.654Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/img/json160.gif",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 200,
+                  "statusText": "",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "date",
+                          "value": "Wed, 16 Sep 2020 12:55:37 GMT"
+                      },
+                      {
+                          "name": "last-modified",
+                          "value": "Tue, 07 Feb 2006 03:48:01 GMT"
+                      },
+                      {
+                          "name": "server",
+                          "value": "Apache"
+                      },
+                      {
+                          "name": "etag",
+                          "value": "\"2ec7-40c2c3ef23e40\""
+                      },
+                      {
+                          "name": "content-type",
+                          "value": "image/gif"
+                      },
+                      {
+                          "name": "status",
+                          "value": "200"
+                      },
+                      {
+                          "name": "accept-ranges",
+                          "value": "bytes"
+                      },
+                      {
+                          "name": "content-length",
+                          "value": "11975"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 11975,
+                      "mimeType": "image/gif"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 11975
+              },
+              "time": 302.09499999999423,
+              "cache": {},
+              "timings": {
+                  "blocked": 25.839999999995857,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 23.804999999995857,
+                  "send": 0.2729999999999997,
+                  "ssl": -1,
+                  "wait": 252.17700000000252,
+                  "_blocked_queueing": 23.804999999995857
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.655Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/img/object.png",
+                  "httpVersion": "http/1.1",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 503,
+                  "statusText": "Service Unavailable",
+                  "httpVersion": "http/1.1",
+                  "headers": [
+                      {
+                          "name": "content-length",
+                          "value": "2"
+                      },
+                      {
+                          "name": "x-intercept-header",
+                          "value": "foobar"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 2,
+                      "mimeType": "text/plain"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 2
+              },
+              "time": 3.172000000006392,
+              "cache": {},
+              "timings": {
+                  "blocked": 1.586000000003196,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 1.586000000003196,
+                  "send": 0,
+                  "ssl": -1,
+                  "wait": 0,
+                  "_blocked_queueing": 1.586000000003196
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.655Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/img/array.png",
+                  "httpVersion": "unknown",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 0,
+                  "statusText": "",
+                  "httpVersion": "unknown",
+                  "headers": [],
+                  "cookies": [],
+                  "content": {
+                      "size": 0,
+                      "mimeType": "x-unknown"
+                  },
+                  "redirectURL": "",
+                  "headersSize": -1,
+                  "bodySize": -1,
+                  "_error": "net::ERR_FAILED"
+              },
+              "time": 0,
+              "cache": {},
+              "timings": {
+                  "blocked": -1,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 0,
+                  "send": 0,
+                  "ssl": -1,
+                  "wait": 0,
+                  "_blocked_queueing": -1
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.655Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/img/value.png",
+                  "httpVersion": "unknown",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 0,
+                  "statusText": "",
+                  "httpVersion": "unknown",
+                  "headers": [],
+                  "cookies": [],
+                  "content": {
+                      "size": 0,
+                      "mimeType": "x-unknown"
+                  },
+                  "redirectURL": "",
+                  "headersSize": -1,
+                  "bodySize": -1,
+                  "_error": "net::ERR_TIMED_OUT"
+              },
+              "time": 0,
+              "cache": {},
+              "timings": {
+                  "blocked": -1,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 0,
+                  "send": 0,
+                  "ssl": -1,
+                  "wait": 0,
+                  "_blocked_queueing": -1
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.655Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/img/string.png",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 200,
+                  "statusText": "",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "date",
+                          "value": "Wed, 16 Sep 2020 12:55:37 GMT"
+                      },
+                      {
+                          "name": "last-modified",
+                          "value": "Fri, 27 Sep 2019 05:23:33 GMT"
+                      },
+                      {
+                          "name": "server",
+                          "value": "Apache"
+                      },
+                      {
+                          "name": "etag",
+                          "value": "\"c401-5938216511f40\""
+                      },
+                      {
+                          "name": "content-type",
+                          "value": "image/png"
+                      },
+                      {
+                          "name": "status",
+                          "value": "200"
+                      },
+                      {
+                          "name": "accept-ranges",
+                          "value": "bytes"
+                      },
+                      {
+                          "name": "content-length",
+                          "value": "50177"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 50177,
+                      "mimeType": "image/png"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 50177
+              },
+              "time": 320.935999999989,
+              "cache": {},
+              "timings": {
+                  "blocked": 28.945999999993564,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 27.562999999993565,
+                  "send": 0.6100000000000001,
+                  "ssl": -1,
+                  "wait": 263.8170000000019,
+                  "_blocked_queueing": 27.562999999993565
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.655Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/img/number.png",
+                  "httpVersion": "unknown",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 0,
+                  "statusText": "",
+                  "httpVersion": "unknown",
+                  "headers": [],
+                  "cookies": [],
+                  "content": {
+                      "size": 0,
+                      "mimeType": "x-unknown"
+                  },
+                  "redirectURL": "",
+                  "headersSize": -1,
+                  "bodySize": -1,
+                  "_error": "net::ERR_ADDRESS_UNREACHABLE"
+              },
+              "time": 0,
+              "cache": {},
+              "timings": {
+                  "blocked": -1,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 0,
+                  "send": 0,
+                  "ssl": -1,
+                  "wait": 0,
+                  "_blocked_queueing": -1
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.655Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/img/whitespace.png",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 200,
+                  "statusText": "",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "date",
+                          "value": "Wed, 16 Sep 2020 12:55:37 GMT"
+                      },
+                      {
+                          "name": "last-modified",
+                          "value": "Fri, 27 Sep 2019 05:28:30 GMT"
+                      },
+                      {
+                          "name": "server",
+                          "value": "Apache"
+                      },
+                      {
+                          "name": "etag",
+                          "value": "\"483f-593822804fb80\""
+                      },
+                      {
+                          "name": "content-type",
+                          "value": "image/png"
+                      },
+                      {
+                          "name": "status",
+                          "value": "200"
+                      },
+                      {
+                          "name": "accept-ranges",
+                          "value": "bytes"
+                      },
+                      {
+                          "name": "content-length",
+                          "value": "18495"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 18495,
+                      "mimeType": "image/png"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 18495
+              },
+              "time": 322.5669999999994,
+              "cache": {},
+              "timings": {
+                  "blocked": 28.725000000000957,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 27.54600000000096,
+                  "send": 0.524,
+                  "ssl": -1,
+                  "wait": 265.7719999999975,
+                  "_blocked_queueing": 27.54600000000096
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.670Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/Programma-Bold.woff2",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "Origin",
+                          "value": "https://www.json.org"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "font"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 200,
+                  "statusText": "",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "status",
+                          "value": "200"
+                      },
+                      {
+                          "name": "date",
+                          "value": "Wed, 16 Sep 2020 12:55:37 GMT"
+                      },
+                      {
+                          "name": "last-modified",
+                          "value": "Sat, 01 Aug 2020 23:39:01 GMT"
+                      },
+                      {
+                          "name": "server",
+                          "value": "Apache"
+                      },
+                      {
+                          "name": "accept-ranges",
+                          "value": "bytes"
+                      },
+                      {
+                          "name": "etag",
+                          "value": "\"85fc-5abd968f9af40\""
+                      },
+                      {
+                          "name": "content-length",
+                          "value": "34300"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 34300,
+                      "mimeType": "application/octet-stream"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 34300
+              },
+              "time": 277.3339999999962,
+              "cache": {},
+              "timings": {
+                  "blocked": 14.118999999996683,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 13.084999999996683,
+                  "send": 0.43399999999999994,
+                  "ssl": -1,
+                  "wait": 249.69600000000284,
+                  "_blocked_queueing": 13.084999999996683
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          },
+          {
+              "startedDateTime": "2020-09-16T12:55:37.991Z",
+              "request": {
+                  "method": "GET",
+                  "url": "https://www.json.org/favicon.gif",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "Referer",
+                          "value": "https://www.json.org/json-en.html"
+                      },
+                      {
+                          "name": "User-Agent",
+                          "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36"
+                      },
+                      {
+                          "name": "Sec-Fetch-Dest",
+                          "value": "image"
+                      }
+                  ],
+                  "headersSize": -1,
+                  "bodySize": 0,
+                  "cookies": [],
+                  "queryString": []
+              },
+              "response": {
+                  "status": 200,
+                  "statusText": "",
+                  "httpVersion": "h2",
+                  "headers": [
+                      {
+                          "name": "date",
+                          "value": "Wed, 16 Sep 2020 12:55:37 GMT"
+                      },
+                      {
+                          "name": "last-modified",
+                          "value": "Fri, 27 Jan 2012 21:18:34 GMT"
+                      },
+                      {
+                          "name": "server",
+                          "value": "Apache"
+                      },
+                      {
+                          "name": "etag",
+                          "value": "\"137-4b7890a0efe80\""
+                      },
+                      {
+                          "name": "content-type",
+                          "value": "image/gif"
+                      },
+                      {
+                          "name": "status",
+                          "value": "200"
+                      },
+                      {
+                          "name": "accept-ranges",
+                          "value": "bytes"
+                      },
+                      {
+                          "name": "content-length",
+                          "value": "311"
+                      }
+                  ],
+                  "headersSize": 0,
+                  "cookies": [],
+                  "content": {
+                      "size": 311,
+                      "mimeType": "image/gif"
+                  },
+                  "redirectURL": "",
+                  "bodySize": 311
+              },
+              "time": 79.49900000000554,
+              "cache": {},
+              "timings": {
+                  "blocked": 5.294000000001545,
+                  "connect": -1,
+                  "dns": -1,
+                  "receive": 4.764000000001545,
+                  "send": 0.2859999999999999,
+                  "ssl": -1,
+                  "wait": 69.15500000000245,
+                  "_blocked_queueing": 4.764000000001545
+              },
+              "pageref": "0908A2D2117805883D74919A844510C3"
+          }
+      ]
+  }
+}

--- a/tests/__fixtures__/preparedData.js
+++ b/tests/__fixtures__/preparedData.js
@@ -3,6 +3,6 @@ import { List } from 'immutable';
 import networkDataMock from './network.json';
 import { prepareViewerData } from './../../src/utils';
 
-const preparedMockData = new List(prepareViewerData(networkDataMock.log.entries).data);
+const preparedMockData = List(prepareViewerData(networkDataMock.log.entries).data);
 
 export default preparedMockData;

--- a/tests/__tests__/Components/ReqDetail/headers/General.spec.jsx
+++ b/tests/__tests__/Components/ReqDetail/headers/General.spec.jsx
@@ -12,4 +12,9 @@ describe('General', () => {
     const element = shallow(<General {...props} />);
     expect(element).toMatchSnapshot();
   });
+
+  it('renders intercept error', () => {
+    const element = shallow(<General data={{ error: 'ERR_TIMED_OUT' }} />);
+    expect(element).toMatchSnapshot();
+  });
 });

--- a/tests/__tests__/Components/ReqDetail/headers/__snapshots__/General.spec.jsx.snap
+++ b/tests/__tests__/Components/ReqDetail/headers/__snapshots__/General.spec.jsx.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`General renders intercept error 1`] = `
+<div>
+  <p
+    key="url"
+  >
+    <span>
+      Request URL:
+    </span>
+    <span />
+  </p>
+  <p
+    key="method"
+  >
+    <span>
+      Request Method:
+    </span>
+    <span />
+  </p>
+  <p
+    key="status"
+  >
+    <span>
+      Status Code:
+    </span>
+    <span>
+      ERR_TIMED_OUT
+    </span>
+  </p>
+  <p
+    key="serverIPAddress"
+  >
+    <span>
+      Remote Address:
+    </span>
+    <span />
+  </p>
+</div>
+`;
+
 exports[`General renders without crashing 1`] = `
 <div>
   <p

--- a/tests/__tests__/__snapshots__/utils.spec.js.snap
+++ b/tests/__tests__/__snapshots__/utils.spec.js.snap
@@ -65,6 +65,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Bold.subset.e96c15f68c68.woff2",
     "headers": Object {
       "postData": undefined,
@@ -229,6 +230,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "slice",
     "headers": Object {
       "postData": undefined,
@@ -400,6 +402,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Regular.subset.bbc33fb47cf6.woff2",
     "headers": Object {
       "postData": undefined,
@@ -559,6 +562,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Bold.subset.e96c15f68c68.woff2",
     "headers": Object {
       "postData": undefined,
@@ -718,6 +722,7 @@ Array [
   Object {
     "body": ".logo{display:block;grid-area:I;width:200px;height:44px;margin-right:24px}",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-header.2a659f6ad280.css",
     "headers": Object {
       "postData": undefined,
@@ -877,6 +882,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-mdn.c66d8d89d98e.css",
     "headers": Object {
       "postData": undefined,
@@ -1041,6 +1047,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Regular.subset.bbc33fb47cf6.woff2",
     "headers": Object {
       "postData": undefined,
@@ -1299,6 +1306,7 @@ Object {
     Object {
       "body": "",
       "domain": "developer.mozilla.org",
+      "error": null,
       "filename": "slice",
       "headers": Object {
         "postData": undefined,
@@ -1470,6 +1478,7 @@ Object {
     Object {
       "body": "",
       "domain": "developer.mozilla.org",
+      "error": null,
       "filename": "ZillaSlab-Regular.subset.bbc33fb47cf6.woff2",
       "headers": Object {
         "postData": undefined,
@@ -1629,6 +1638,7 @@ Object {
     Object {
       "body": "",
       "domain": "developer.mozilla.org",
+      "error": null,
       "filename": "ZillaSlab-Bold.subset.e96c15f68c68.woff2",
       "headers": Object {
         "postData": undefined,
@@ -1788,6 +1798,7 @@ Object {
     Object {
       "body": ".logo{display:block;grid-area:I;width:200px;height:44px;margin-right:24px}",
       "domain": "developer.mozilla.org",
+      "error": null,
       "filename": "react-header.2a659f6ad280.css",
       "headers": Object {
         "postData": undefined,
@@ -1947,6 +1958,7 @@ Object {
     Object {
       "body": "",
       "domain": "developer.mozilla.org",
+      "error": null,
       "filename": "react-mdn.c66d8d89d98e.css",
       "headers": Object {
         "postData": undefined,
@@ -2123,11 +2135,949 @@ Object {
 }
 `;
 
+exports[`utils prepareViewerData when intercept error exists 1`] = `
+Object {
+  "data": Array [
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "https://www.json.org/",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": ":authority",
+            "value": "www.json.org",
+          },
+          Object {
+            "name": ":method",
+            "value": "GET",
+          },
+          Object {
+            "name": ":path",
+            "value": "/",
+          },
+          Object {
+            "name": ":scheme",
+            "value": "https",
+          },
+          Object {
+            "name": "accept",
+            "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          },
+          Object {
+            "name": "accept-encoding",
+            "value": "gzip, deflate, br",
+          },
+          Object {
+            "name": "accept-language",
+            "value": "en-US,en;q=0.9",
+          },
+          Object {
+            "name": "cache-control",
+            "value": "no-cache",
+          },
+          Object {
+            "name": "pragma",
+            "value": "no-cache",
+          },
+          Object {
+            "name": "sec-fetch-dest",
+            "value": "document",
+          },
+          Object {
+            "name": "sec-fetch-mode",
+            "value": "navigate",
+          },
+          Object {
+            "name": "sec-fetch-site",
+            "value": "none",
+          },
+          Object {
+            "name": "sec-fetch-user",
+            "value": "?1",
+          },
+          Object {
+            "name": "upgrade-insecure-requests",
+            "value": "1",
+          },
+          Object {
+            "name": "user-agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "content-encoding",
+            "value": "gzip",
+          },
+          Object {
+            "name": "content-type",
+            "value": "text/html",
+          },
+          Object {
+            "name": "date",
+            "value": "Wed, 16 Sep 2020 12:55:36 GMT",
+          },
+          Object {
+            "name": "etag",
+            "value": "W/\\"106-5988862f8ccc0\\"",
+          },
+          Object {
+            "name": "last-modified",
+            "value": "Sat, 30 Nov 2019 04:00:27 GMT",
+          },
+          Object {
+            "name": "server",
+            "value": "Apache",
+          },
+          Object {
+            "name": "status",
+            "value": "200",
+          },
+        ],
+      },
+      "index": 0,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "262 B",
+      "startedDateTime": 1600260937093,
+      "status": 200,
+      "time": 306.29300000000603,
+      "timings": Object {
+        "_blocked_queueing": 7.4600000000017985,
+        "blocked": 87.0090000000018,
+        "connect": 139.756,
+        "dns": 0.014999999999986358,
+        "receive": 7.4600000000017985,
+        "send": 1.6730000000000018,
+        "ssl": 85.43700000000001,
+        "startTime": 0,
+        "wait": 70.38000000000244,
+      },
+      "transferredSize": 262,
+      "type": "html",
+      "uncompressedSize": 262,
+      "url": "https://www.json.org/",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "json-en.html",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": ":authority",
+            "value": "www.json.org",
+          },
+          Object {
+            "name": ":method",
+            "value": "GET",
+          },
+          Object {
+            "name": ":path",
+            "value": "/json-en.html",
+          },
+          Object {
+            "name": ":scheme",
+            "value": "https",
+          },
+          Object {
+            "name": "accept",
+            "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+          },
+          Object {
+            "name": "accept-encoding",
+            "value": "gzip, deflate, br",
+          },
+          Object {
+            "name": "accept-language",
+            "value": "en-US,en;q=0.9",
+          },
+          Object {
+            "name": "cache-control",
+            "value": "no-cache",
+          },
+          Object {
+            "name": "pragma",
+            "value": "no-cache",
+          },
+          Object {
+            "name": "referer",
+            "value": "https://www.json.org/",
+          },
+          Object {
+            "name": "sec-fetch-dest",
+            "value": "document",
+          },
+          Object {
+            "name": "sec-fetch-mode",
+            "value": "navigate",
+          },
+          Object {
+            "name": "sec-fetch-site",
+            "value": "same-origin",
+          },
+          Object {
+            "name": "upgrade-insecure-requests",
+            "value": "1",
+          },
+          Object {
+            "name": "user-agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "content-encoding",
+            "value": "gzip",
+          },
+          Object {
+            "name": "content-type",
+            "value": "text/html",
+          },
+          Object {
+            "name": "date",
+            "value": "Wed, 16 Sep 2020 12:55:37 GMT",
+          },
+          Object {
+            "name": "etag",
+            "value": "W/\\"685e-59d342586ba40\\"",
+          },
+          Object {
+            "name": "last-modified",
+            "value": "Tue, 28 Jan 2020 14:36:17 GMT",
+          },
+          Object {
+            "name": "server",
+            "value": "Apache",
+          },
+          Object {
+            "name": "status",
+            "value": "200",
+          },
+        ],
+      },
+      "index": 1,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "26.1 KB",
+      "startedDateTime": 1600260937547,
+      "status": 200,
+      "time": 95.31199999999984,
+      "timings": Object {
+        "_blocked_queueing": 9.427000000002295,
+        "blocked": 9.927000000002295,
+        "connect": -1,
+        "dns": -1,
+        "receive": 9.427000000002295,
+        "send": 0.31200000000000006,
+        "ssl": -1,
+        "startTime": 454,
+        "wait": 75.64599999999525,
+      },
+      "transferredSize": 26718,
+      "type": "html",
+      "uncompressedSize": 26718,
+      "url": "https://www.json.org/json-en.html",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "favicon.ico",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "accept-ranges",
+            "value": "bytes",
+          },
+          Object {
+            "name": "content-length",
+            "value": "989",
+          },
+          Object {
+            "name": "content-type",
+            "value": "image/vnd.microsoft.icon",
+          },
+          Object {
+            "name": "date",
+            "value": "Wed, 16 Sep 2020 12:55:37 GMT",
+          },
+          Object {
+            "name": "etag",
+            "value": "\\"3dd-4b788cfa56180\\"",
+          },
+          Object {
+            "name": "last-modified",
+            "value": "Fri, 27 Jan 2012 21:02:14 GMT",
+          },
+          Object {
+            "name": "server",
+            "value": "Apache",
+          },
+          Object {
+            "name": "status",
+            "value": "200",
+          },
+        ],
+      },
+      "index": 2,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "989 B",
+      "startedDateTime": 1600260937545,
+      "status": 200,
+      "time": 88.92100000000625,
+      "timings": Object {
+        "_blocked_queueing": 10.395000000002597,
+        "blocked": 10.908000000002597,
+        "connect": -1,
+        "dns": -1,
+        "receive": 10.395000000002597,
+        "send": 0.6789999999999999,
+        "ssl": -1,
+        "startTime": 452,
+        "wait": 66.93900000000106,
+      },
+      "transferredSize": 989,
+      "type": "vnd.microsoft.icon",
+      "uncompressedSize": 989,
+      "url": "https://www.json.org/favicon.ico",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "json160.gif",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "accept-ranges",
+            "value": "bytes",
+          },
+          Object {
+            "name": "content-length",
+            "value": "11975",
+          },
+          Object {
+            "name": "content-type",
+            "value": "image/gif",
+          },
+          Object {
+            "name": "date",
+            "value": "Wed, 16 Sep 2020 12:55:37 GMT",
+          },
+          Object {
+            "name": "etag",
+            "value": "\\"2ec7-40c2c3ef23e40\\"",
+          },
+          Object {
+            "name": "last-modified",
+            "value": "Tue, 07 Feb 2006 03:48:01 GMT",
+          },
+          Object {
+            "name": "server",
+            "value": "Apache",
+          },
+          Object {
+            "name": "status",
+            "value": "200",
+          },
+        ],
+      },
+      "index": 3,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "11.7 KB",
+      "startedDateTime": 1600260937654,
+      "status": 200,
+      "time": 302.09499999999423,
+      "timings": Object {
+        "_blocked_queueing": 23.804999999995857,
+        "blocked": 25.839999999995857,
+        "connect": -1,
+        "dns": -1,
+        "receive": 23.804999999995857,
+        "send": 0.2729999999999997,
+        "ssl": -1,
+        "startTime": 561,
+        "wait": 252.17700000000252,
+      },
+      "transferredSize": 11975,
+      "type": "gif",
+      "uncompressedSize": 11975,
+      "url": "https://www.json.org/img/json160.gif",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "object.png",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "content-length",
+            "value": "2",
+          },
+          Object {
+            "name": "x-intercept-header",
+            "value": "foobar",
+          },
+        ],
+      },
+      "index": 4,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "2 B",
+      "startedDateTime": 1600260937655,
+      "status": 503,
+      "time": 3.172000000006392,
+      "timings": Object {
+        "_blocked_queueing": 1.586000000003196,
+        "blocked": 1.586000000003196,
+        "connect": -1,
+        "dns": -1,
+        "receive": 1.586000000003196,
+        "send": 0,
+        "ssl": -1,
+        "startTime": 562,
+        "wait": 0,
+      },
+      "transferredSize": 2,
+      "type": "",
+      "uncompressedSize": 2,
+      "url": "https://www.json.org/img/object.png",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": "net::ERR_FAILED",
+      "filename": "array.png",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [],
+      },
+      "index": 5,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": 0,
+      "startedDateTime": 1600260937655,
+      "status": 0,
+      "time": 0,
+      "timings": Object {
+        "_blocked_queueing": -1,
+        "blocked": -1,
+        "connect": -1,
+        "dns": -1,
+        "receive": 0,
+        "send": 0,
+        "ssl": -1,
+        "startTime": 562,
+        "wait": 0,
+      },
+      "transferredSize": -1,
+      "type": "",
+      "uncompressedSize": -1,
+      "url": "https://www.json.org/img/array.png",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": "net::ERR_TIMED_OUT",
+      "filename": "value.png",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [],
+      },
+      "index": 6,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": 0,
+      "startedDateTime": 1600260937655,
+      "status": 0,
+      "time": 0,
+      "timings": Object {
+        "_blocked_queueing": -1,
+        "blocked": -1,
+        "connect": -1,
+        "dns": -1,
+        "receive": 0,
+        "send": 0,
+        "ssl": -1,
+        "startTime": 562,
+        "wait": 0,
+      },
+      "transferredSize": -1,
+      "type": "",
+      "uncompressedSize": -1,
+      "url": "https://www.json.org/img/value.png",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "string.png",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "accept-ranges",
+            "value": "bytes",
+          },
+          Object {
+            "name": "content-length",
+            "value": "50177",
+          },
+          Object {
+            "name": "content-type",
+            "value": "image/png",
+          },
+          Object {
+            "name": "date",
+            "value": "Wed, 16 Sep 2020 12:55:37 GMT",
+          },
+          Object {
+            "name": "etag",
+            "value": "\\"c401-5938216511f40\\"",
+          },
+          Object {
+            "name": "last-modified",
+            "value": "Fri, 27 Sep 2019 05:23:33 GMT",
+          },
+          Object {
+            "name": "server",
+            "value": "Apache",
+          },
+          Object {
+            "name": "status",
+            "value": "200",
+          },
+        ],
+      },
+      "index": 7,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "49 KB",
+      "startedDateTime": 1600260937655,
+      "status": 200,
+      "time": 320.935999999989,
+      "timings": Object {
+        "_blocked_queueing": 27.562999999993565,
+        "blocked": 28.945999999993564,
+        "connect": -1,
+        "dns": -1,
+        "receive": 27.562999999993565,
+        "send": 0.6100000000000001,
+        "ssl": -1,
+        "startTime": 562,
+        "wait": 263.8170000000019,
+      },
+      "transferredSize": 50177,
+      "type": "png",
+      "uncompressedSize": 50177,
+      "url": "https://www.json.org/img/string.png",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": "net::ERR_ADDRESS_UNREACHABLE",
+      "filename": "number.png",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [],
+      },
+      "index": 8,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": 0,
+      "startedDateTime": 1600260937655,
+      "status": 0,
+      "time": 0,
+      "timings": Object {
+        "_blocked_queueing": -1,
+        "blocked": -1,
+        "connect": -1,
+        "dns": -1,
+        "receive": 0,
+        "send": 0,
+        "ssl": -1,
+        "startTime": 562,
+        "wait": 0,
+      },
+      "transferredSize": -1,
+      "type": "",
+      "uncompressedSize": -1,
+      "url": "https://www.json.org/img/number.png",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "whitespace.png",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "accept-ranges",
+            "value": "bytes",
+          },
+          Object {
+            "name": "content-length",
+            "value": "18495",
+          },
+          Object {
+            "name": "content-type",
+            "value": "image/png",
+          },
+          Object {
+            "name": "date",
+            "value": "Wed, 16 Sep 2020 12:55:37 GMT",
+          },
+          Object {
+            "name": "etag",
+            "value": "\\"483f-593822804fb80\\"",
+          },
+          Object {
+            "name": "last-modified",
+            "value": "Fri, 27 Sep 2019 05:28:30 GMT",
+          },
+          Object {
+            "name": "server",
+            "value": "Apache",
+          },
+          Object {
+            "name": "status",
+            "value": "200",
+          },
+        ],
+      },
+      "index": 9,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "18.1 KB",
+      "startedDateTime": 1600260937655,
+      "status": 200,
+      "time": 322.5669999999994,
+      "timings": Object {
+        "_blocked_queueing": 27.54600000000096,
+        "blocked": 28.725000000000957,
+        "connect": -1,
+        "dns": -1,
+        "receive": 27.54600000000096,
+        "send": 0.524,
+        "ssl": -1,
+        "startTime": 562,
+        "wait": 265.7719999999975,
+      },
+      "transferredSize": 18495,
+      "type": "png",
+      "uncompressedSize": 18495,
+      "url": "https://www.json.org/img/whitespace.png",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "Programma-Bold.woff2",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Origin",
+            "value": "https://www.json.org",
+          },
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "font",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "accept-ranges",
+            "value": "bytes",
+          },
+          Object {
+            "name": "content-length",
+            "value": "34300",
+          },
+          Object {
+            "name": "date",
+            "value": "Wed, 16 Sep 2020 12:55:37 GMT",
+          },
+          Object {
+            "name": "etag",
+            "value": "\\"85fc-5abd968f9af40\\"",
+          },
+          Object {
+            "name": "last-modified",
+            "value": "Sat, 01 Aug 2020 23:39:01 GMT",
+          },
+          Object {
+            "name": "server",
+            "value": "Apache",
+          },
+          Object {
+            "name": "status",
+            "value": "200",
+          },
+        ],
+      },
+      "index": 10,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "33.5 KB",
+      "startedDateTime": 1600260937670,
+      "status": 200,
+      "time": 277.3339999999962,
+      "timings": Object {
+        "_blocked_queueing": 13.084999999996683,
+        "blocked": 14.118999999996683,
+        "connect": -1,
+        "dns": -1,
+        "receive": 13.084999999996683,
+        "send": 0.43399999999999994,
+        "ssl": -1,
+        "startTime": 577,
+        "wait": 249.69600000000284,
+      },
+      "transferredSize": 34300,
+      "type": "",
+      "uncompressedSize": 34300,
+      "url": "https://www.json.org/Programma-Bold.woff2",
+    },
+    Object {
+      "body": undefined,
+      "domain": "www.json.org",
+      "error": null,
+      "filename": "favicon.gif",
+      "headers": Object {
+        "postData": undefined,
+        "queryString": Array [],
+        "request": Array [
+          Object {
+            "name": "Referer",
+            "value": "https://www.json.org/json-en.html",
+          },
+          Object {
+            "name": "Sec-Fetch-Dest",
+            "value": "image",
+          },
+          Object {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36",
+          },
+        ],
+        "response": Array [
+          Object {
+            "name": "accept-ranges",
+            "value": "bytes",
+          },
+          Object {
+            "name": "content-length",
+            "value": "311",
+          },
+          Object {
+            "name": "content-type",
+            "value": "image/gif",
+          },
+          Object {
+            "name": "date",
+            "value": "Wed, 16 Sep 2020 12:55:37 GMT",
+          },
+          Object {
+            "name": "etag",
+            "value": "\\"137-4b7890a0efe80\\"",
+          },
+          Object {
+            "name": "last-modified",
+            "value": "Fri, 27 Jan 2012 21:18:34 GMT",
+          },
+          Object {
+            "name": "server",
+            "value": "Apache",
+          },
+          Object {
+            "name": "status",
+            "value": "200",
+          },
+        ],
+      },
+      "index": 11,
+      "method": "GET",
+      "serverIPAddress": ":80",
+      "size": "311 B",
+      "startedDateTime": 1600260937991,
+      "status": 200,
+      "time": 79.49900000000554,
+      "timings": Object {
+        "_blocked_queueing": 4.764000000001545,
+        "blocked": 5.294000000001545,
+        "connect": -1,
+        "dns": -1,
+        "receive": 4.764000000001545,
+        "send": 0.2859999999999999,
+        "ssl": -1,
+        "startTime": 898,
+        "wait": 69.15500000000245,
+      },
+      "transferredSize": 311,
+      "type": "gif",
+      "uncompressedSize": 311,
+      "url": "https://www.json.org/favicon.gif",
+    },
+  ],
+  "finishTime": 982.2630000000071,
+  "totalNetworkTime": 982.262939453125,
+  "totalRequests": 12,
+  "totalTransferredSize": 143226,
+  "totalUncompressedSize": 143226,
+}
+`;
+
 exports[`utils sortBy 1`] = `
 Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "slice",
     "headers": Object {
       "postData": undefined,
@@ -2299,6 +3249,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-mdn.c66d8d89d98e.css",
     "headers": Object {
       "postData": undefined,
@@ -2458,6 +3409,7 @@ Array [
   Object {
     "body": ".logo{display:block;grid-area:I;width:200px;height:44px;margin-right:24px}",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-header.2a659f6ad280.css",
     "headers": Object {
       "postData": undefined,
@@ -2617,6 +3569,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Regular.subset.bbc33fb47cf6.woff2",
     "headers": Object {
       "postData": undefined,
@@ -2776,6 +3729,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Bold.subset.e96c15f68c68.woff2",
     "headers": Object {
       "postData": undefined,

--- a/tests/__tests__/state/__snapshots__/reducer.spec.js.snap
+++ b/tests/__tests__/state/__snapshots__/reducer.spec.js.snap
@@ -4,6 +4,7 @@ exports[`network reducer SELECT_REQUEST 1`] = `
 Object {
   "body": "",
   "domain": "developer.mozilla.org",
+  "error": null,
   "filename": "slice",
   "headers": Object {
     "postData": undefined,
@@ -179,6 +180,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "slice",
     "headers": Object {
       "postData": undefined,
@@ -350,6 +352,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Regular.subset.bbc33fb47cf6.woff2",
     "headers": Object {
       "postData": undefined,
@@ -509,6 +512,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Bold.subset.e96c15f68c68.woff2",
     "headers": Object {
       "postData": undefined,
@@ -668,6 +672,7 @@ Array [
   Object {
     "body": ".logo{display:block;grid-area:I;width:200px;height:44px;margin-right:24px}",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-header.2a659f6ad280.css",
     "headers": Object {
       "postData": undefined,
@@ -827,6 +832,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-mdn.c66d8d89d98e.css",
     "headers": Object {
       "postData": undefined,
@@ -993,6 +999,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Regular.subset.bbc33fb47cf6.woff2",
     "headers": Object {
       "postData": undefined,
@@ -1167,6 +1174,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "slice",
     "headers": Object {
       "postData": undefined,
@@ -1338,6 +1346,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Regular.subset.bbc33fb47cf6.woff2",
     "headers": Object {
       "postData": undefined,
@@ -1497,6 +1506,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Bold.subset.e96c15f68c68.woff2",
     "headers": Object {
       "postData": undefined,
@@ -1656,6 +1666,7 @@ Array [
   Object {
     "body": ".logo{display:block;grid-area:I;width:200px;height:44px;margin-right:24px}",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-header.2a659f6ad280.css",
     "headers": Object {
       "postData": undefined,
@@ -1815,6 +1826,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-mdn.c66d8d89d98e.css",
     "headers": Object {
       "postData": undefined,
@@ -2013,6 +2025,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "slice",
     "headers": Object {
       "postData": undefined,
@@ -2184,6 +2197,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-mdn.c66d8d89d98e.css",
     "headers": Object {
       "postData": undefined,
@@ -2343,6 +2357,7 @@ Array [
   Object {
     "body": ".logo{display:block;grid-area:I;width:200px;height:44px;margin-right:24px}",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "react-header.2a659f6ad280.css",
     "headers": Object {
       "postData": undefined,
@@ -2502,6 +2517,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Regular.subset.bbc33fb47cf6.woff2",
     "headers": Object {
       "postData": undefined,
@@ -2661,6 +2677,7 @@ Array [
   Object {
     "body": "",
     "domain": "developer.mozilla.org",
+    "error": null,
     "filename": "ZillaSlab-Bold.subset.e96c15f68c68.woff2",
     "headers": Object {
       "postData": undefined,

--- a/tests/__tests__/utils.spec.js
+++ b/tests/__tests__/utils.spec.js
@@ -3,6 +3,7 @@ import { List } from 'immutable';
 
 import * as utils from './../../src/utils';
 import networkDataMock from './../__fixtures__/network.json';
+import interceptErrorNetworkDataMock from './../__fixtures__/network_intercept_error.json';
 import preparedMockData from './../__fixtures__/preparedData';
 
 describe('utils', () => {
@@ -30,6 +31,10 @@ describe('utils', () => {
     const { entries } = networkDataMock.log;
     expect(utils.prepareViewerData(entries)).toMatchSnapshot();
     expect(utils.prepareViewerData([])).toMatchSnapshot();
+  });
+
+  it('prepareViewerData when intercept error exists', () => {
+    expect(utils.prepareViewerData(interceptErrorNetworkDataMock.log.entries)).toMatchSnapshot();
   });
 
   it('sortBy', () => {
@@ -201,5 +206,24 @@ describe('utils', () => {
 
   it('findIndexAfterTimestamp', () => {
     expect(utils.findIndexAfterTimestamp(preparedMockData, 1571042835643)).toMatchSnapshot();
+  });
+
+  it('getStatusClass', () => {
+    expect(utils.getStatusClass({ status: 200 })).toBe('info');
+    expect(utils.getStatusClass({ status: 503 })).toBe('error');
+    expect(utils.getStatusClass({ status: 0, error: 'ERR' })).toBe('error');
+    expect(utils.getStatusClass({ status: 0 })).toBe('pending');
+  });
+
+  it('formatValue', () => {
+    expect(utils.formatValue('status', 200)).toBe(200);
+    expect(utils.formatValue('status', 0, '', { error: 'ERR' })).toBe('(failed)');
+    expect(utils.formatValue('status', 0)).toBe('Pending');
+    expect(utils.formatValue('status', 0)).toBe('Pending');
+  });
+
+  it('getInterceptError', () => {
+    expect(utils.getInterceptError({ response: { _error: 'ERR_TIMED_OUT' } })).toBe('ERR_TIMED_OUT');
+    expect(utils.getInterceptError({ response: { } })).toBe(null);
   });
 });


### PR DESCRIPTION
**Problem:** Intercept error message was not supported.

**Solution:** 
- Dislplay intercept error message in status column same as chrome devtools.
- Add failed request when using filter: `error status`
- Display error message in request-details