### PR TITLE
Fix HAR undefined queuing property

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -270,7 +270,7 @@ export const calcTotalTime = (data) => {
 
 export const prepareTooltipData = (data) => ({
   queuedAt: parseTime(data.startTime),
-  startedAt: parseTime(data.startTime + data._blocked_queueing),
+  startedAt: parseTime(data.startTime + (data._blocked_queueing || data._queued || 0)),
   totalTime: parseTime(calcTotalTime(data)),
   ...(Object.keys(data).reduce((acc, key) => {
     acc[key] = parseTime(data[key]);


### PR DESCRIPTION
This fixes `NaN` value in popover due to undefined `_blocked_queueing` property in  HAR files generated by Chrome HAR

https://github.com/sitespeedio/chrome-har/blob/d23393967e1766fa78c001faec244b6b6378c52d/lib/entryFromResponse.js#L198

Fixes #70