### PR TITLE
Include _queued key used by chrome-har to prevent NaN queuing value

### DIFF
--- a/src/Components/NetworkTable/TimeChartTooltip.jsx
+++ b/src/Components/NetworkTable/TimeChartTooltip.jsx
@@ -62,7 +62,7 @@ const TimeChartTooltip = ({ data }) => {
                     {TIMINGS[key].name}
                   </td>
                   <td className={Styles['waterfall-tooltip-value']}>
-                    {tooltipData[TIMINGS[key].dataKey]}
+                    {Array.isArray(TIMINGS[key].dataKey) ? tooltipData[TIMINGS[key].dataKey.find(key => tooltipData[key])] : tooltipData[TIMINGS[key].dataKey]}
                   </td>
                 </tr>
               ))}

--- a/src/constants.js
+++ b/src/constants.js
@@ -108,7 +108,7 @@ export const FETCH_FILE_LOAD_TEXT = 'Please wait, Fetching file is in progress.'
 
 export const TIMINGS = {
   queueing: {
-    dataKey: '_blocked_queueing',
+    dataKey: ['_blocked_queueing', '_queued'],
     fill: '#ccc',
     name: 'Queueing',
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,7 +142,7 @@ export const getHeaders = (entry) => ({
 });
 
 export const getTotalTimeOfEntry = ({ startedDateTime, time, timings }) => (
-  new Date(startedDateTime).getTime() + time + (timings._blocked_queueing || 0)
+  new Date(startedDateTime).getTime() + time + (timings._blocked_queueing || timings._queued || 0)
 );
 
 export const getInterceptError = ({ response }) => (
@@ -263,7 +263,7 @@ export const parseTime = (time) => {
 
 export const calcTotalTime = (data) => {
   const total = Object.keys(data)
-    .filter((key) => !['_blocked_queueing', 'startTime'].includes(key))
+    .filter((key) => !['_blocked_queueing', '_queued', 'startTime'].includes(key))
     .reduce((acc, key) => acc + data[key], 0);
   return total;
 };
@@ -311,7 +311,8 @@ export const calcChartAttributes = (data, maxTime, cx, index, cy = null) => {
 
   Object.keys(TIMINGS).forEach((key) => {
     const timingInfo = TIMINGS[key];
-    const value = data[timingInfo.dataKey];
+    const dataKey = Array.isArray(timingInfo.dataKey) ? timingInfo.dataKey.find(key => data[key]) : timingInfo.dataKey
+    const value = data[dataKey];
     if (value <= 0) {
       return;
     }


### PR DESCRIPTION
### Overview
This PR addresses bugs due to wrong queuing key in HAR files generated by [chrome-har](https://github.com/sitespeedio/chrome-har/blob/d23393967e1766fa78c001faec244b6b6378c52d/lib/entryFromResponse.js#L198)

- Fixes waterfall Tooltip missing `Queuing` value and incorrect `Total time`
![image](https://user-images.githubusercontent.com/100368679/189991372-45647c5c-c6a1-4bcb-9d9c-1ab8ef948408.png)

- Fixes waterfall Timechart going off view due to missing/incorrect total time
![image](https://user-images.githubusercontent.com/100368679/189991568-db46ee79-8985-41bb-ae45-59c907f5e709.png)

