### PR TITLE
Catch error when parsing invalid urls in getUrlInfo, and return fallback

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,18 +28,29 @@ export const formatTime = (time) => {
 };
 
 export const getUrlInfo = (url) => {
-  const urlInfo = new URL(url);
-  const pathSplit = urlInfo.pathname.split('/');
-  const fileName = (
-    pathSplit[pathSplit.length - 1].trim() ?
-      pathSplit[pathSplit.length - 1] : pathSplit[pathSplit.length - 2]
-  ) + urlInfo.search;
+  // If there's an invalid URL (resource identifier, etc) the constructor would throw an exception.
+  // Return a 'placeholder' object with default values in the event the passed value cannot be
+  // parsed.
+  try {
+    const urlInfo = new URL(url);
+    const pathSplit = urlInfo.pathname.split('/');
+    const fileName = (
+      pathSplit[pathSplit.length - 1].trim() ?
+        pathSplit[pathSplit.length - 1] : pathSplit[pathSplit.length - 2]
+    ) + urlInfo.search;
 
-  return {
-    domain: urlInfo.host,
-    filename: fileName || urlInfo.href,
-    url: urlInfo.href,
-  };
+    return {
+      domain: urlInfo.host,
+      filename: fileName || urlInfo.href,
+      url: urlInfo.href,
+    };
+  } catch (er) {
+    return {
+      domain: 'N/A',
+      filename: url ?? 'N/A',
+      url,
+    };
+  }
 };
 
 export const parseSize = ({ bodySize, _transferSize, headers, content }) => {
@@ -311,7 +322,7 @@ export const calcChartAttributes = (data, maxTime, cx, index, cy = null) => {
 
   Object.keys(TIMINGS).forEach((key) => {
     const timingInfo = TIMINGS[key];
-    const dataKey = Array.isArray(timingInfo.dataKey) ? timingInfo.dataKey.find(key => data[key]) : timingInfo.dataKey
+    const dataKey = Array.isArray(timingInfo.dataKey) ? timingInfo.dataKey.find((key) => data[key]) : timingInfo.dataKey;
     const value = data[dataKey];
     if (value <= 0) {
       return;

--- a/tests/__tests__/utils.spec.js
+++ b/tests/__tests__/utils.spec.js
@@ -12,6 +12,17 @@ describe('utils', () => {
     expect(utils.getUrlInfo(url)).toMatchSnapshot();
   });
 
+  it('getUrlInfo non standard url / resource identifier', () => {
+    const resourceName = 'ResourceIdentifierString';
+    const urlInfo = utils.getUrlInfo(resourceName);
+
+    expect(urlInfo).toEqual({
+      domain: 'N/A',
+      filename: resourceName,
+      url: resourceName,
+    });
+  });
+
   it('parseSize', () => {
     const { response } = networkDataMock.log.entries[0];
     expect(utils.parseSize(response)).toMatchSnapshot();


### PR DESCRIPTION
If an invalid URL or resource identifier were passed as an item in a har it would throw an exception and crash the component. I've added a try / catch around the constructor and a fallback in the event the provided url cannot be parsed. Also added a test for the use case.