### PR TITLE
NoDataPlaceholder component prop

### DIFF
--- a/src/Components/NetworkTable/NetworkTable.styles.scss
+++ b/src/Components/NetworkTable/NetworkTable.styles.scss
@@ -9,7 +9,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: $size-xxxl;
+  padding: $size-xxxl $size-l;
+  text-align: center;
+
 
   .network-icon {
     fill: $brand-primary-light-gray;

--- a/src/Components/NetworkTable/NetworkTableBody.jsx
+++ b/src/Components/NetworkTable/NetworkTableBody.jsx
@@ -43,7 +43,7 @@ const NetworkTableBody = ({ height }) => {
     actions,
     callbacks,
   } = useNetwork();
-  const { enableAutoScroll } = useTheme();
+  const { enableAutoScroll, NoDataPlaceholder } = useTheme();
   const numberOfNewEntries = state.get('numberOfNewEntries');
   const data = state.get('data');
   const actualData = state.get('actualData');
@@ -84,8 +84,13 @@ const NetworkTableBody = ({ height }) => {
         className={Styles['no-data']}
       >
         <IconNetworkRequest className={Styles['network-icon']} />
-        <span className={Styles.header}>Recording network activity</span>
-        <span className={Styles.subtext}>Perform a request to see the network activity</span>
+        {NoDataPlaceholder && <NoDataPlaceholder />}
+        {!NoDataPlaceholder && (
+          <>
+            <span className={Styles.header}>Recording network activity</span>
+            <span className={Styles.subtext}>Perform a request to see the network activity</span>
+          </>
+        )}
       </div>
     );
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -289,6 +289,7 @@ export const SECTION_TITLES = Object.freeze({
 export const MAX_COLOR_CONTENT_SIZE = 100000; // 100kB
 export const TIMELINE_DATA_POINT_HEIGHT = 2;
 export const NETWORK_VIEWER_DEFAULT_OPTIONS = {
+  NoDataPlaceholder: undefined,
   enableAutoScroll: false,
   showExportHar: false,
   showImportHar: true,


### PR DESCRIPTION
## Description
Pass a component prop `NoDataPlaceholder` to be displayed when there is no data to be shown and the import button is disabled. If the prop exists, it will replace the default placeholder.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
