### PR TITLE
bump actions/upload-artifact and actions/download-artifact

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build package
         run: npm run build:package:ci
       - name: Upload built package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: compiled-package
           path: |
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Download built package
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: compiled-package
       - name: Release


### PR DESCRIPTION
## Description
actions/upload-artifact and actions/download-artifact were deprecated causing the build action to fail.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change

