### PR TITLE
Fix issue where network table height is not updated on initial load

### DIFF
--- a/src/Components/NetworkTable/NetworkTableBody.jsx
+++ b/src/Components/NetworkTable/NetworkTableBody.jsx
@@ -51,7 +51,7 @@ const NetworkTableBody = ({ height }) => {
   const selectedReqIndex = state.get('selectedReqIndex');
 
   const listRef = useRef(null);
-  const { elementDims } = useResizeObserver(listRef?.current?._outerRef || listRef?.current);
+  const { elementDims } = useResizeObserver(listRef);
 
   useEffect(() => {
     actions.setTableHeaderWidth(elementDims.width);

--- a/src/Containers/NetworkTableContainer.jsx
+++ b/src/Containers/NetworkTableContainer.jsx
@@ -23,7 +23,7 @@ const NetworkTableContainer = () => {
 
   const [tableBodyHeight, setTableBodyHeight] = useState(0);
   const ref = useRef();
-  const { elementDims } = useResizeObserver(ref?.current);
+  const { elementDims } = useResizeObserver(ref);
 
   useEffect(() => {
     if (ref?.current && elementDims.height) {

--- a/src/Containers/NetworkTableContainer.jsx
+++ b/src/Containers/NetworkTableContainer.jsx
@@ -26,7 +26,7 @@ const NetworkTableContainer = () => {
   const { elementDims } = useResizeObserver(ref?.current);
 
   useEffect(() => {
-    if (ref?.current && elementDims.height) {
+    if (ref?.current && ref?.current.clientHeight) {
       setTableBodyHeight(ref.current.clientHeight - TABLE_HEADER_HEIGHT);
     }
   }, [ref?.current, actualData, elementDims]);

--- a/src/Containers/NetworkTableContainer.jsx
+++ b/src/Containers/NetworkTableContainer.jsx
@@ -26,7 +26,7 @@ const NetworkTableContainer = () => {
   const { elementDims } = useResizeObserver(ref?.current);
 
   useEffect(() => {
-    if (ref?.current && ref?.current.clientHeight) {
+    if (ref?.current && elementDims.height) {
       setTableBodyHeight(ref.current.clientHeight - TABLE_HEADER_HEIGHT);
     }
   }, [ref?.current, actualData, elementDims]);

--- a/src/hooks/useResizeObserver.js
+++ b/src/hooks/useResizeObserver.js
@@ -19,24 +19,25 @@ export const useResizeObserver = (elementRef) => {
   });
 
   useEffect(() => {
+    const ref = elementRef?.current?._outerRef || elementRef?.current;
     const onResize = debounce(() => {
-      if (elementRef?.current) {
+      if (ref) {
         setElementDims({
-          width: elementRef?.current.clientWidth,
-          height: elementRef?.current.clientHeight,
+          width: ref.clientWidth,
+          height: ref.clientHeight,
         });
       }
     }, 50);
 
     const resizeObserver = new ResizeObserver(() => onResize());
 
-    if (elementRef?.current) {
-      resizeObserver.observe(elementRef?.current);
+    if (ref) {
+      resizeObserver.observe(ref);
     }
 
     return () => {
-      if (elementRef?.current) {
-        resizeObserver.unobserve(elementRef?.current);
+      if (ref) {
+        resizeObserver.unobserve(ref);
       }
     };
   }, [elementRef?.current]);

--- a/src/hooks/useResizeObserver.js
+++ b/src/hooks/useResizeObserver.js
@@ -20,26 +20,26 @@ export const useResizeObserver = (elementRef) => {
 
   useEffect(() => {
     const onResize = debounce(() => {
-      if (elementRef) {
+      if (elementRef?.current) {
         setElementDims({
-          width: elementRef.clientWidth,
-          height: elementRef.clientHeight,
+          width: elementRef?.current.clientWidth,
+          height: elementRef?.current.clientHeight,
         });
       }
     }, 50);
 
     const resizeObserver = new ResizeObserver(() => onResize());
 
-    if (elementRef) {
-      resizeObserver.observe(elementRef);
+    if (elementRef?.current) {
+      resizeObserver.observe(elementRef?.current);
     }
 
     return () => {
-      if (elementRef) {
-        resizeObserver.unobserve(elementRef);
+      if (elementRef?.current) {
+        resizeObserver.unobserve(elementRef?.current);
       }
     };
-  }, [elementRef]);
+  }, [elementRef?.current]);
 
   return { elementDims };
 };


### PR DESCRIPTION
# One-line summary

> Issue : RDX-664

## Description
When the network viewer is loaded for the first time, the height of `<NetworkTableBody>` is initialized as 0, but does not immediately update its height based on the data. The data is there, but it's not visible, until switching to another sub-tab, and then back to the "All" tab.

~~This seems to happen because the `resizeObserver` for `elementDims` does not trigger on this initial load, so the dimensions stay as 0. And we only update `tableBodyHeight` if `elementDims` is non-zero for some reason.~~

~~The fix is to check `ref.current.clientHeight` instead of `elementDims`. This value seems to be more accurately gauged as non-zero on initial page load. And we don't seem to care about the exact value, just that it's non-zero.~~

The root cause was basically this line in NetworkTableContainer:

```
  const { elementDims } = useResizeObserver(ref?.current);
```
That `ref?.current` gets evaluated the first time to `undefined`, and then passed to `useResizeObserver` which uses it as a dependency for its `useEffect` function. But because it was already evaluated to `undefined`, it's no longer a `MutableRefObject` and can never update, and so the effect never triggers.

I changed this to simply pass through the `MutableRefObject` ref, and changed the code inside `useResizeObserver` to make it work with this change. I also had to make changes to `NetworkTableBody`, the other place where `useResizeObserver` is used.

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
