### PR TITLE
Cleanup for ref used for react-window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 yarn.lock
+
+.vscode

--- a/src/Components/NetworkTable/NetworkTableBody.jsx
+++ b/src/Components/NetworkTable/NetworkTableBody.jsx
@@ -59,11 +59,12 @@ const NetworkTableBody = ({ height }) => {
 
   useEffect(() => {
     if (enableAutoScroll && listRef?.current) {
-      const needToScroll = listRef?.current.scrollTop +
-        listRef?.current.offsetHeight +
-        (numberOfNewEntries * TABLE_ENTRY_HEIGHT) >= listRef?.current.scrollHeight;
+      const { offsetHeight, scrollHeight } = listRef.current;
+      let { scrollTop } = listRef.current;
+      const needToScroll = scrollTop + offsetHeight +
+        (numberOfNewEntries * TABLE_ENTRY_HEIGHT) >= scrollHeight;
       if (needToScroll) {
-        listRef.current.scrollTop = listRef?.current.scrollHeight;
+        scrollTop = scrollHeight;
       }
     }
   }, [data, listRef]);

--- a/src/Components/NetworkTable/NetworkTableBody.jsx
+++ b/src/Components/NetworkTable/NetworkTableBody.jsx
@@ -58,13 +58,12 @@ const NetworkTableBody = ({ height }) => {
   }, [elementDims]);
 
   useEffect(() => {
-    if (enableAutoScroll && listRef?.current?._outerRef) {
-      const outerRef = listRef?.current?._outerRef;
-      const needToScroll = outerRef.scrollTop +
-        outerRef.offsetHeight +
-        (numberOfNewEntries * TABLE_ENTRY_HEIGHT) >= outerRef.scrollHeight;
+    if (enableAutoScroll && listRef?.current) {
+      const needToScroll = listRef?.current.scrollTop +
+        listRef?.current.offsetHeight +
+        (numberOfNewEntries * TABLE_ENTRY_HEIGHT) >= listRef?.current.scrollHeight;
       if (needToScroll) {
-        listRef.current._outerRef.scrollTop = outerRef.scrollHeight;
+        listRef.current.scrollTop = listRef?.current.scrollHeight;
       }
     }
   }, [data, listRef]);
@@ -100,7 +99,6 @@ const NetworkTableBody = ({ height }) => {
   return (
     <>
       <FixedSizeList
-        ref={listRef}
         className={Styles['network-table-body']}
         height={height}
         itemCount={data.size}
@@ -111,6 +109,7 @@ const NetworkTableBody = ({ height }) => {
           selectedReqIndex,
         }}
         itemSize={TABLE_ENTRY_HEIGHT}
+        outerRef={listRef}
       >
         {virtualizedTableRow}
       </FixedSizeList>

--- a/src/hooks/useResizeObserver.js
+++ b/src/hooks/useResizeObserver.js
@@ -19,7 +19,7 @@ export const useResizeObserver = (elementRef) => {
   });
 
   useEffect(() => {
-    const ref = elementRef?.current?._outerRef || elementRef?.current;
+    const ref = elementRef?.current;
     const onResize = debounce(() => {
       if (ref) {
         setElementDims({
@@ -40,7 +40,7 @@ export const useResizeObserver = (elementRef) => {
         resizeObserver.unobserve(ref);
       }
     };
-  }, [elementRef?.current]);
+  }, [elementRef]);
 
   return { elementDims };
 };


### PR DESCRIPTION

## Description
We are using _outref (privtate/internal) ref from `react-widow`. Instead the API already [exposes](https://github.com/bvaughn/react-window/blob/72db696dd8ebb7f0f287c78d037ff68ba9534183/src/createListComponent.js#L74) `outerRef` as prop to `FixedSizeList`. We should exposed props to have better control over refs and avoid using internal api if it's not necessary.

It works but we are using a readonly ref. If we set it byourselves we have complete access to it how we would like to initialise it and even what could be target outer element for the `FixedSizeList`